### PR TITLE
Added node binding

### DIFF
--- a/Fable.Parsimmon.Tests/Parsimmon.Tests.fs
+++ b/Fable.Parsimmon.Tests/Parsimmon.Tests.fs
@@ -460,3 +460,13 @@ QUnit.test "Parsimmon.ofLazy works with list of digits parser" <| fun test ->
     |> function 
         | Some (Many [Element 1; Many [Element 5; Element 6; Element 7]; Many [Element 1]]) -> test.passWith "many nested elements many list case works"
         | otherwise -> test.failWith "many nested elements many list case fails"
+
+QUnit.test "Parsimmon.node works with correct positions" <| fun test -> 
+    let pA = Parsimmon.letter "a" |> Parsimmon.many
+    let p = Parsimmon.between pA Parsimmon.digits pA
+    let result =
+        Parsimmon.parse "ab12dc" p
+        |> Parsimmon.node "digits"
+
+    test.isTrue result.status
+    test.equal "12" result.value

--- a/Fable.Parsimmon/Parsimmon.fs
+++ b/Fable.Parsimmon/Parsimmon.fs
@@ -12,6 +12,17 @@ type IParserOffSet =
     abstract line : int
     abstract column : int
 
+type TokenPosition =
+    { offset: int
+      line: int
+      column: int }
+
+type NodeResult<'t> =
+    { name: string
+      value: 't
+      start: TokenPosition
+      ``end``: TokenPosition }
+
 type IParser<'t> = 
     abstract map<'u> : ('t -> 'u) -> IParser<'u>
     abstract parse : string -> ParseResult<'t>
@@ -32,6 +43,8 @@ type IParser<'t> =
     [<Emit("$0.or($1)")>]
     abstract orTry : IParser<'t> -> IParser<'t>
     abstract sepBy1 : IParser<'u> -> IParser<'t []>
+    [<Emit("$0.node($1)")>]
+    abstract node(name: string): IParser<NodeResult<'t>> = jsNative
 
 module Parsimmon = 
     let parseRaw (input: string) (parser: IParser<'t>) =
@@ -202,7 +215,7 @@ module Parsimmon =
     let trim (trimmed: IParser<'a>) (p: IParser<'t>) : IParser<'t> = 
         p.trim trimmed
     
-    /// Equavilant to `parser.map (String.concat "")`
+    /// Equivalent to `parser.map (String.concat "")`
     let concat (parser: IParser<string[]>) : IParser<string> =
         parser.map (String.concat "")
     
@@ -223,3 +236,6 @@ module Parsimmon =
              (p4: IParser<'w>) 
              (p5: IParser<'q>) : IParser<'t * 'u * 'v * 'w * 'q> =  
         import "seq" "./Parsimmon.js"
+
+    /// Equivalent to `parser.node("description")`
+    let node<'t> description (p:IParser<'t>) = parser.node(description)


### PR DESCRIPTION
Hi @Zaid-Ajaj, we talked about this a while ago on gitter.
I have a need of using [the node function](https://github.com/Zaid-Ajaj/Fable.Parsimmon/blob/master/Fable.Parsimmon/Parsimmon.js#L1021).

I couldn't run the test on my local machine so I kinda winged it there.

```
ERROR in ./Fable.Parsimmon.Tests/Parsimmon.Tests.fs
Module build failed (from ./node_modules/fable-loader/index.js):
Error: File C:/temp/Fable.Parsimmon/Fable.Parsimmon.Tests/Parsimmon.Tests.fs doesn't belong to parsed project (C:/temp/Fable.Parsimmon/Fable.Parsimmon.Tests/Parsimmon.Tests.fs)
    at Loader.fableUtils.client.send.then.r (C:\temp\Fable.Parsimmon\node_modules\fable-loader\index.js:67:22)
 @ ./Fable.Parsimmon.Tests/Fable.Parsimmon.Tests.fsproj 1:0-37 1:0-37
 @ multi @babel/polyfill ./Fable.Parsimmon.Tests/Fable.Parsimmon.Tests.fsproj
npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! @ build: `webpack-cli --mode production`
npm ERR! Exit status 2
npm ERR!
npm ERR! Failed at the @ build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     c:\_builds\npm-cache\_logs\2018-12-17T13_20_05_718Z-debug.log
Closing Fable daemon...
```

Not sure what went wrong there.